### PR TITLE
Maintain eco-bot; switch to discord.py; beg command and overall improvements

### DIFF
--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -164,7 +164,7 @@ class Economy(commands.Cog):
     @cooldown(1, 10, BucketType.user)
     async def beg(self, ctx):
         """ Beg for some money from strangers """
-        beg_amount = random.randint(0, 1000)
+        beg_amount = random.randint(0, 500)
         user_bal = await economy_collection.find_one({"id": ctx.author.id})
         if not user_bal:
             await self.open_account(ctx.author.id)

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -160,7 +160,27 @@ class Economy(commands.Cog):
                 {"id": user.id}, {"$set": receiver_account}
             )
             await ctx.send(f"You have sent ${amount} to {user}")
-
+    @commands.command()
+    @cooldown(1, 10, BucketType.user)
+    async def beg(self, ctx):
+        """ Beg for some money from strangers """
+        beg_amount = random.randint(0, 1000)
+        user_bal = await economy_collection.find_one({"id": ctx.author.id})
+        if not user_bal:
+            await self.open_account(ctx.author.id)
+            user_bal = await economy_collection.find_one({"id": ctx.author.id})
+        await economy_collection.update_one({"id": ctx.author.id}, {"$inc": {"wallet": +beg_amount}})
+        reactions = ['💸', '🤑', '💰', '💳', '💵']
+        excuses = ["You're lucky I have a heart of gold!",
+                   "Don't beg, just take what you want.",
+                   "I'm not as poor as you think I am.",
+                   "I'm feeling generous today, so here you go!",
+                   "You're welcome."]
+        excuse = random.choice(excuses)
+        embed = discord.Embed(title=random.choice(reactions), description = f"{ctx.author.mention} {excuse} ${beg_amount}")
+        embed.color = discord.Color.gold()
+        embed.set_footer(text=f"Requested by {ctx.author.display_name}", icon_url=ctx.author.avatar.url)
+        await ctx.channel.send(embed=embed)
     @commands.command()
     @cooldown(1, 2, BucketType.user)
     async def gamble(self, ctx, amount: int):

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -8,185 +8,168 @@ import nest_asyncio
 import json
 import random
 
-with open('./data.json') as f:
-    d1 = json.load(f)
-with open('./market.json') as f:
-    d2 = json.load(f)
-
 nest_asyncio.apply()
 
-mongo_url = d1['mongo']
+with open('./data.json') as f:
+    config = json.load(f)
 
-cluster = motor.motor_asyncio.AsyncIOMotorClient(mongo_url)
-ecomoney = cluster["eco"]["money"]
+cluster = motor.motor_asyncio.AsyncIOMotorClient(config["mongo"])
+economy_collection = cluster["eco"]["money"]
+
 
 class Economy(commands.Cog):
-    """ Commands related to economy"""
+    """Commands related to economy"""
+
     def __init__(self, bot):
         self.bot = bot
 
     @commands.Cog.listener()
     async def on_ready(self):
-        print("Eco Cog Loaded Succesfully")
+        print("Economy cog loaded successfully")
 
-    async def open_account(self, id : int):
-            newuser = {"id": id, "wallet": 0, "bank": 100}
-            # wallet = current money, bank = money in bank
-            await ecomoney.insert_one(newuser)
+    async def create_account(self, user_id):
+        new_account = {"id": user_id, "wallet": 0, "bank": 100}
+        await economy_collection.insert_one(new_account)
 
-    async def update_wallet(self, id : int, wallet : int):
-        if id is not None:
-            await ecomoney.update_one({"id": id}, {"$set": {"wallet": wallet}})
+    async def update_wallet(self, user_id, amount):
+        await economy_collection.update_one(
+            {"id": user_id}, {"$set": {"wallet": amount}}
+        )
 
-    async def update_bank(self, id : int, bank : int):
-        if id is not None:
-            await ecomoney.update_one({"id": id}, {"$set": {"bank": bank}})
-
+    async def update_bank(self, user_id, amount):
+        await economy_collection.update_one(
+            {"id": user_id}, {"$set": {"bank": amount}}
+        )
 
     @commands.command(aliases=["bal"])
     @cooldown(1, 2, BucketType.user)
     async def balance(self, ctx, user: discord.Member = None):
-        """ Check your balance"""
+        """Check your balance"""
         if user is None:
             user = ctx.author
-        try:
-            bal = await ecomoney.find_one({"id": user.id})
-            if bal is None:
-                await self.open_account(user.id)
-                bal = await ecomoney.find_one({"id": user.id})
-            embed = discord.Embed(
-                timestamp=ctx.message.created_at,
-                title=f"{user}'s Balance",
-                color=0xFF0000,
-            )
-            embed.add_field(
-                name="Wallet",
-                value=f"${bal['wallet']}",
-            )
-            embed.add_field(
-                name="Bank",
-                value=f"${bal['bank']}",
-            )
-            embed.set_footer(
-                text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
-            )
-            embed.set_thumbnail(url=user.avatar_url)
-            await ctx.send(embed=embed)
-        except Exception:
-            await ctx.send('An error occured')
+        account = await economy_collection.find_one({"id": user.id})
+        if account is None:
+            await self.create_account(user.id)
+            account = await economy_collection.find_one({"id": user.id})
+        embed = discord.Embed(
+            timestamp=ctx.message.created_at,
+            title=f"{user}'s Balance",
+            color=0xFF0000,
+        )
+        embed.add_field(name="Wallet", value=f"${account['wallet']}")
+        embed.add_field(name="Bank", value=f"${account['bank']}")
+        embed.set_footer(
+            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
+        )
+        embed.set_thumbnail(url=user.avatar.url)
+        await ctx.send(embed=embed)
 
     @commands.command(aliases=["wd"])
     @cooldown(1, 2, BucketType.user)
     async def withdraw(self, ctx, amount: int):
-        """ Withdraw money from your bank"""
-        user = ctx.author
-        try:
-            bal = await ecomoney.find_one({"id": user.id})
-            if bal is None:
-                await self.open_account(user.id)
-                bal = await ecomoney.find_one({"id": user.id})
-            if amount > bal['bank']:
-                await ctx.send('You do not have enough money to withdraw that much')
-            elif amount <= 0:
-                await ctx.send('You cannot withdraw 0 or less')
-            else:
-                await ecomoney.update_one({"id": user.id}, {"$inc": {"wallet": +amount, "bank": -amount}})
-                await ctx.send(f'You have withdrawn ${amount}')
-        except Exception:
-            await ctx.send('An error occured')
+        """Withdraw money from your bank"""
+        account = await economy_collection.find_one({"id": ctx.author.id})
+        if account is None:
+            await self.create_account(ctx.author.id)
+            account = await economy_collection.find_one({"id": ctx.author.id})
+        if amount > account["bank"]:
+            await ctx.send("You do not have enough money to withdraw that much")
+        elif amount <= 0:
+            await ctx.send("You cannot withdraw 0 or less")
+        else:
+            await self.update_wallet(ctx.author.id, account["wallet"] + amount)
+            await self.update_bank(ctx.author.id, account["bank"] - amount)
+            await ctx.send(f"You have withdrawn ${amount}")
 
     @commands.command(aliases=["dp"])
     @cooldown(1, 2, BucketType.user)
     async def deposit(self, ctx, amount: int):
-        """ Deposit money to your bank"""
-        user = ctx.author
-        try:
-            bal = await ecomoney.find_one({"id": user.id})
-            if bal is None:
-                await self.open_account(user.id)
-                bal = await ecomoney.find_one({"id": user.id})
-            if amount > bal['wallet']:
-                await ctx.send('You do not have enough money to deposit that much')
-            elif amount <= 0:
-                await ctx.send('You cannot deposit 0 or less')
-            else:
-                await ecomoney.update_one({"id": user.id}, {"$inc": {"wallet": -amount, "bank": +amount}})
-                await ctx.send(f'You have deposited ${amount}')
-        except Exception:
-            await ctx.send('An error occured')
+        """Deposit money to your bank"""
+        account = await economy_collection.find_one({"id": ctx.author.id})
+        if account is None:
+            await self.create_account(ctx.author.id)
+            account = await economy_collection.find_one({"id": ctx.author.id})
+        if amount > account["wallet"]:
+            await ctx.send("You do not have enough money to deposit that much")
+        elif amount <= 0:
+            await ctx.send("You cannot deposit 0 or less")
+        else:
+            await self.update_wallet(ctx.author.id, account["wallet"] - amount)
+            await self.update_bank(ctx.author.id, account["bank"] + amount)
+            await ctx.send(f"You have deposited ${amount}")
 
     @commands.command()
     @cooldown(1, 2, BucketType.user)
     async def rob(self, ctx, user: discord.Member = None):
-        """ Rob someone"""
+        """Rob someone"""
         if user is None or user.id == ctx.author.id:
-            await ctx.send('Trying to rob yourself?')
+            await ctx.send("Trying to rob yourself?")
         else:
-            try:
-                user_bal = await ecomoney.find_one({"id": user.id})
-                member_bal = await ecomoney.find_one({"id": ctx.author.id})
-                if user_bal is None:
-                    await self.open_account(user.id)
-                    user_bal = await ecomoney.find_one({"id": user.id})
-                if member_bal is None:
-                    await self.open_account(ctx.author.id)
-                    member_bal = await ecomoney.find_one({"id": ctx.author.id})
-                mem_bank = member_bal["bank"]
-                user_bank = user_bal["bank"]
-                if mem_bank < 100:
-                    await ctx.send('You do not have enough money to rob someone')
-                elif mem_bank >= 100:
-                    if user_bank < 100:
-                        await ctx.send('User do not have enough money to get robbed ;-;')
-                    elif user_bank >= 100:
-                        num = random.randint(1, 100)
-                        f_mem = mem_bank + num
-                        f_user = user_bank - num
-                        await self.update_bank(ctx.author.id, f_mem)
-                        await self.update_bank(user.id, f_user)
-                        await ctx.send('You have robbed ${num} from {user}'.format(num=num, user=user))
+            victim_account = await economy_collection.find_one({"id": user.id})
+            if victim_account is None:
+                await self.create_account(user.id)
+                victim_account = await economy_collection.find_one({"id": user.id})
+            robbers_account = await economy_collection.find_one({"id": ctx.author.id})
+            if robbers_account is None:
+                await self.create_account(ctx.author.id)
+                robbers_account = await economy_collection.find_one({"id": ctx.author.id})
+            robber_bank = robbers_account["bank"]
+            victim_bank = victim_account["bank"]
+            if robber_bank < 100:
+                await ctx.send("You do not have enough money to rob someone")
+            elif robber_bank >= 100:
+                if victim_bank < 100:
+                    await ctx.send("User do not have enough money to get robbed ;-;")
+                elif victim_bank >= 100:
+                    amount = random.randint(1, 100)
+                    robbers_account["bank"] += amount
+                    victim_account["bank"] -= amount
+                    await economy_collection.update_one(
+                        {"id": ctx.author.id}, {"$set": robbers_account}
+                    )
+                    await economy_collection.update_one(
+                        {"id": user.id}, {"$set": victim_account}
+                    )
+                    await ctx.send(f"You have robbed ${amount} from {user}")
 
-
-            except Exception:
-                await ctx.send('An error occured')
-
-    # send money to another user
     @commands.command()
     @cooldown(1, 2, BucketType.user)
     async def send(self, ctx, user: discord.Member, amount: int):
-        """ Send money to another user"""
-        try:
-            user_bal = await ecomoney.find_one({"id": user.id})
-            member_bal = await ecomoney.find_one({"id": ctx.author.id})
-            if user_bal is None:
-                await self.open_account(user.id)
-                user_bal = await ecomoney.find_one({"id": user.id})
-            if member_bal is None:
-                await self.open_account(ctx.author.id)
-                member_bal = await ecomoney.find_one({"id": ctx.author.id})
-            mem_bank = member_bal["bank"]
-            user_bank = user_bal["bank"]
-            if amount > mem_bank or amount > 20000:
-                await ctx.send('You do not have enough money to send that much or amount too much')
-            elif amount <= 0:
-                await ctx.send('You cannot send 0 or less')
-            else:
-                await ecomoney.update_one({"id": ctx.author.id}, {"$inc": {"bank": -amount}})
-                await ecomoney.update_one({"id": user.id}, {"$inc": {"bank": +amount}})
-                await ctx.send(f'You have sent ${amount} to {user}')
-        except Exception:
-            await ctx.send('An error occured')
+        """Send money to another user"""
+        receiver_account = await economy_collection.find_one({"id": user.id})
+        sender_account = await economy_collection.find_one({"id": ctx.author.id})
+        if receiver_account is None:
+            await self.create_account(user.id)
+            receiver_account = await economy_collection.find_one({"id": user.id})
+        if sender_account is None:
+            await self.create_account(ctx.author.id)
+            sender_account = await economy_collection.find_one({"id": ctx.author.id})
+        sender_bank = sender_account["bank"]
+        receiver_bank = receiver_account["bank"]
+        if amount > sender_bank or amount > 20000:
+            await ctx.send("You do not have enough money to send that much")
+        elif amount <= 0:
+            await ctx.send("You cannot send 0 or less")
+        else:
+            sender_account["bank"] -= amount
+            receiver_account["bank"] += amount
+            await economy_collection.update_one(
+                {"id": ctx.author.id}, {"$set": sender_account}
+            )
+            await economy_collection.update_one(
+                {"id": user.id}, {"$set": receiver_account}
+            )
+            await ctx.send(f"You have sent ${amount} to {user}")
 
-    # A economy bot fun command
     @commands.command()
     @cooldown(1, 2, BucketType.user)
     async def gamble(self, ctx, amount: int):
         """ Gamble money"""
         try:
-            user_bal = await ecomoney.find_one({"id": ctx.author.id})
+            user_bal = await economy_collection.find_one({"id": ctx.author.id})
             if user_bal is None:
                 await self.open_account(ctx.author.id)
-                user_bal = await ecomoney.find_one({"id": ctx.author.id})
+                user_bal = await economy_collection.find_one({"id": ctx.author.id})
             if amount > user_bal["wallet"]:
                 await ctx.send('You do not have enough money to gamble that much')
             elif amount <= 0:
@@ -194,13 +177,13 @@ class Economy(commands.Cog):
             else:
                 num = random.randint(1, 100)
                 if num <= 50:
-                    await ecomoney.update_one({"id": ctx.author.id}, {"$inc": {"wallet": +amount}})
+                    await economy_collection.update_one({"id": ctx.author.id}, {"$inc": {"wallet": +amount}})
                     await ctx.send(f'You have won ${amount}')
                 elif num > 50:
-                    await ecomoney.update_one({"id": ctx.author.id}, {"$inc": {"wallet": -amount}})
+                    await economy_collection.update_one({"id": ctx.author.id}, {"$inc": {"wallet": -amount}})
                     await ctx.send(f'You have lost ${amount}')
         except Exception:
-            await ctx.send('An error occured')
-
+            await ctx.send('An error occurred')
+   
 def setup(bot):
     bot.add_cog(Economy(bot))

--- a/cogs/errors.py
+++ b/cogs/errors.py
@@ -111,6 +111,13 @@ class Errors(commands.Cog):
         traceback.print_exception(
             type(error), error, error.__traceback__, file=sys.stderr
         )
+        embed = discord.Embed(
+            title="Unknown error",
+            description=str(sys.stderr),
+            color=0xFF0000,
+        )
+        await ctx.send(embed=embed)
+            
 
 
 def setup(bot):

--- a/cogs/errors.py
+++ b/cogs/errors.py
@@ -113,7 +113,7 @@ class Errors(commands.Cog):
         )
         embed = discord.Embed(
             title="Unknown error",
-            description=str(sys.stderr),
+            description=str(error),
             color=0xFF0000,
         )
         await ctx.send(embed=embed)

--- a/cogs/info.py
+++ b/cogs/info.py
@@ -47,7 +47,7 @@ class Info(commands.Cog):
             text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
 
-        embed.set_thumbnail(url=ctx.guild.icon_url)
+        embed.set_thumbnail(url=ctx.guild.icon.url)
 
         await ctx.send(embed=embed)
 

--- a/cogs/info.py
+++ b/cogs/info.py
@@ -44,7 +44,7 @@ class Info(commands.Cog):
             name="Prefix", value=f"`.`", inline=False
         )
         embed.set_footer(
-            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
+            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
 
         embed.set_thumbnail(url=ctx.guild.icon_url)
@@ -59,7 +59,7 @@ class Info(commands.Cog):
         embed = discord.Embed(
             timestamp=ctx.message.created_at, title=":robot:  Bot Info", color=0xFF0000
         )
-        embed.set_thumbnail(url=self.bot.user.avatar_url)
+        embed.set_thumbnail(url=self.bot.user.avatar.url)
         embed.add_field(
             name="Helping", value=f"{ser} servers"
         )
@@ -80,10 +80,10 @@ class Info(commands.Cog):
             value="[Checkout my website](https://....)",
         )
         embed.add_field(
-            name="Made By", value="Mini.py#5183"
+            name="Made By", value="`@_mini.dev`\n`@infinotiver`"
         )
         embed.set_footer(
-            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
+            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
         await ctx.send(embed=embed)
 
@@ -101,7 +101,7 @@ class Info(commands.Cog):
             title="User Info",
             color=0xFF0000,
         )
-        embed.set_thumbnail(url=member.avatar_url)
+        embed.set_thumbnail(url=member.avatar.url)
         embed.add_field(name=":name_badge: Name", value=f"{member.name}")
         embed.add_field(
             name="Nickname", value=f"{member.nick}"
@@ -116,7 +116,7 @@ class Info(commands.Cog):
             value=f"{member.top_role.mention}",
         )
         embed.set_footer(
-            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
+            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
         await ctx.send(embed=embed)
 

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -90,7 +90,7 @@ class Shop(commands.Cog):
             inline=False
         )
         embed.set_footer(
-        text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
+        text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
 
         await ctx.send(embed=embed)
@@ -111,7 +111,7 @@ class Shop(commands.Cog):
                 inline=False
             )
         embed.set_footer(
-            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
+            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
         await ctx.send(embed=embed)
 
@@ -131,7 +131,7 @@ class Shop(commands.Cog):
                 inline=False
             )
         embed.set_footer(
-            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
+            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
         await ctx.send(embed=embed)
 
@@ -151,7 +151,7 @@ class Shop(commands.Cog):
                 inline=False
             )
         embed.set_footer(
-            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
+            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
         await ctx.send(embed=embed)
 
@@ -310,7 +310,7 @@ class Shop(commands.Cog):
             embed.add_field(name=fg[2], value=f"{x[1]}", inline=False)
 
         embed.set_footer(
-            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
+            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
         await ctx.send(embed=embed)
 
@@ -345,7 +345,7 @@ class Shop(commands.Cog):
 
 
         embed.set_footer(
-            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar_url}"
+            text=f"Requested By: {ctx.author.name}", icon_url=f"{ctx.author.avatar.url}"
         )
         await ctx.send(embed=embed)
         

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import discord
 import json
 
 from discord.ext import commands
-from pretty_help import PrettyHelp
+
 
 
 class Echo(commands.Bot):
@@ -17,7 +17,6 @@ class Echo(commands.Bot):
             command_prefix={"."},
             owner_ids={727365670395838626},
             intents=discord.Intents.all(),
-            help_command=PrettyHelp(),
             description=self.description,
             case_insensitive=True,
             start_time=datetime.utcnow(),

--- a/main.py
+++ b/main.py
@@ -15,7 +15,6 @@ class Echo(commands.Bot):
 
         super().__init__(
             command_prefix={"."},
-            owner_ids={727365670395838626},
             intents=discord.Intents.all(),
             description=self.description,
             case_insensitive=True,

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ class Echo(commands.Bot):
             intents=discord.Intents.all(),
             description=self.description,
             case_insensitive=True,
-            start_time=datetime.utcnow(),
+
         )
 
     async def on_connnect(self):

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ class Echo(commands.Bot):
 
         )
 
-    async def on_connnect(self):
+    async def on_connect(self):
         self.session = aiohttp.ClientSession(loop=self.loop)
 
         cT = datetime.now() + timedelta(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-discord.py
-jishaku
-motor
-psutil
-nest_asyncio
-dnspython
+discord.py==2.3.2
+jishaku==2.5.2
+motor==3.4.0
+psutil==5.9.8
+nest-asyncio==1.6.0
+dnspython==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-py-cord
+discord.py
 jishaku
-discord-pretty-help
 motor
 psutil
 nest_asyncio


### PR DESCRIPTION
Hello @AyushSehrawat, as mentioned in #32 
here is my initial pr which revamps the fundamentals of eco-bot
## Here is a list of what changed
* `py-cord` --> `discord.py` : Discord.py is a lot convenient and popularly used and maintained regularly now
* migrate to `discord.py` :  Certain methods were outdated, for eg. `avatar_url`; `icon_url` etc
* Update in error handling : I removed try and except and instead added error handling in the `Errors` cog
* Beg command : For poor folks to earn some currency
* Bot Info Command : Updated your username and added mine
* Remove `discord-pretty-help` : `help-command` no longer works as desired

If you want, I can fully migrate this bot to support slash commands (but that would require some intense labour which I am unwilling to do )

:)